### PR TITLE
Added code that checks a hosts templates, groups and interfaces before deciding to run the :update action.

### DIFF
--- a/providers/host.rb
+++ b/providers/host.rb
@@ -87,6 +87,7 @@ action :create_or_update do
       if update_host
         Chef::Log.debug 'Going to update this host'
         run_action :update
+        new_resource.updated_by_last_action(true)
       end
     end
   end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -7,7 +7,7 @@ action :create_or_update do
           :host => new_resource.hostname
         },
         :selectParentTemplates => ['host'],
-        :selectInterfaces => ['main','type','useip','ip','dns','port'],
+        :selectInterfaces => ['main', 'type', 'useip', 'ip', 'dns', 'port'],
         :selectGroups => ['name']
       }
     }
@@ -21,31 +21,31 @@ action :create_or_update do
 
       # Compare templates
       current_templates = []
-      hosts[0]["parentTemplates"].each do |tmpl|
+      hosts[0]['parentTemplates'].each do |tmpl|
         current_templates << tmpl['host']
       end
 
       if current_templates.sort != new_resource.templates.sort
-          update_host = true
-          Chef::Log.debug "Current templates and new templates differ"
+        update_host = true
+        Chef::Log.debug 'Current templates and new templates differ'
       end
 
       # Compare groups
       current_groups = []
-      hosts[0]["groups"].each do |grp|
-        current_groups << grp["name"]
+      hosts[0]['groups'].each do |grp|
+        current_groups << grp['name']
       end
 
       if current_groups.sort != new_resource.groups.sort
         update_host = true
-        Chef::Log.debug "Current groups and new groups differ"
+        Chef::Log.debug 'Current groups and new groups differ'
       end
 
       # Compare interfaces
       new_interfaces = []
       new_resource.interfaces.each do |int|
         new_interfaces << {
-          'type'  => int[:type]::value.to_s,
+          'type'  => int[:type].value.to_s,
           'main'  => int[:main].to_s,
           'ip'    => int[:ip],
           'dns'   => int[:dns],
@@ -55,33 +55,37 @@ action :create_or_update do
       end
 
       # New interfaces that do not yet exist?
+      found = false
       new_interfaces.each do |new_int|
-        found = false
         hosts[0]['interfaces'].each do|cur_int|
           if new_int.eql?(cur_int)
             found = true
+            break
           end
-        end
-        if !found
-          update_host = true
-          Chef::Log.debug "New hostinterface required"
-          Chef::Log.debug new_int
         end
       end
 
+      unless found
+        update_host = true
+        Chef::Log.debug 'New hostinterface required'
+        Chef::Log.debug new_int
+      end
+
       # Existing interfaces that should be removed?
+      found = false
       hosts[0]['interfaces'].each do |cur_int|
-        found = false
         new_interfaces.each do|new_int|
           if new_int.eql?(cur_int)
             found = true
+            break
           end
         end
-        if !found
-          update_host = true
-          Chef::Log.debug "Hostinterface to be removed"
-          Chef::Log.debug cur_int
-        end
+      end
+
+      unless found
+        update_host = true
+        Chef::Log.debug 'Hostinterface to be removed'
+        Chef::Log.debug cur_int
       end
 
       if update_host


### PR DESCRIPTION
I Added templates, groups and interfaces to the query at the top of the create_or_update action.
After checking if the host already exists in zabbix, templates, groups and interfaces for the new_resource object are now compared to what is already in zabbix.

This avoids the counter of "updated resources" to increase on every chef-client run.
