### PR TITLE
Updates to templateid associations

### DIFF
--- a/libraries/chef_zabbix_api.rb
+++ b/libraries/chef_zabbix_api.rb
@@ -96,7 +96,7 @@ class Chef
       class << self
         def find_hostgroup_ids(connection, hostgroup)
           group_id_request = {
-            :method => 'hostgroups.get',
+            :method => 'hostgroup.get',
             :params => {
               :filter => {
                 :name => hostgroup
@@ -108,7 +108,7 @@ class Chef
 
         def find_template_ids(connection, template)
           get_template_request = {
-            :method => 'templates.get',
+            :method => 'template.get',
             :params => {
               :filter => {
                 :host => template,
@@ -120,7 +120,7 @@ class Chef
 
         def find_application_ids(connection, application, template_id)
           request = {
-            :method => 'applications.get',
+            :method => 'application.get',
             :params => {
               :hostids => template_id,
               :filter => {
@@ -133,7 +133,7 @@ class Chef
 
         def find_lld_rule_ids(connection, template_id, key)
           request = {
-            :method => 'discoveryrules.get',
+            :method => 'discoveryrule.get',
             :params => {
               :templated => true,
               :templateids => template_id,
@@ -147,7 +147,7 @@ class Chef
 
         def find_trigger_ids(connection, description)
           request = {
-            :method => 'triggers.get',
+            :method => 'trigger.get',
             :params => {
               :search => {
                 :description => description
@@ -159,7 +159,7 @@ class Chef
 
         def find_trigger_prototype_ids(connection, description)
           request = {
-            :method => 'triggerprototypes.get',
+            :method => 'triggerprototype.get',
             :params => {
               :search => {
                 :description => description
@@ -171,7 +171,7 @@ class Chef
 
         def find_item_ids(connection, template_id, key, name = nil)
           request = {
-            :method => 'items.get',
+            :method => 'item.get',
             :params => {
               :hostids => template_id,
               :search => {
@@ -190,7 +190,7 @@ class Chef
 
         def find_item_prototype_ids(connection, template_id, key, discovery_rule_id = nil)
           request = {
-            :method => 'itemprototypes.get',
+            :method => 'itemprototype.get',
             :params => {
               :templateids => template_id,
               :search => {
@@ -206,7 +206,7 @@ class Chef
 
         def find_item_ids_on_host(connection, host, key)
           request = {
-            :method => 'items.get',
+            :method => 'item.get',
             :params => {
               :host => host,
               :search => {
@@ -219,7 +219,7 @@ class Chef
 
         def find_graph_ids(connection, name)
           request = {
-            :method => 'graphs.get',
+            :method => 'graph.get',
             :params => {
               :filter => {
                 :name => name
@@ -231,7 +231,7 @@ class Chef
 
         def find_graph_prototype_ids(connection, name)
           request = {
-            :method => 'graphprototypes.get',
+            :method => 'graphprototype.get',
             :params => {
               :filter => {
                 :name => name

--- a/libraries/chef_zabbix_api.rb
+++ b/libraries/chef_zabbix_api.rb
@@ -96,7 +96,7 @@ class Chef
       class << self
         def find_hostgroup_ids(connection, hostgroup)
           group_id_request = {
-            :method => 'hostgroup.get',
+            :method => 'hostgroups.get',
             :params => {
               :filter => {
                 :name => hostgroup
@@ -108,7 +108,7 @@ class Chef
 
         def find_template_ids(connection, template)
           get_template_request = {
-            :method => 'template.get',
+            :method => 'templates.get',
             :params => {
               :filter => {
                 :host => template,
@@ -120,7 +120,7 @@ class Chef
 
         def find_application_ids(connection, application, template_id)
           request = {
-            :method => 'application.get',
+            :method => 'applications.get',
             :params => {
               :hostids => template_id,
               :filter => {
@@ -133,7 +133,7 @@ class Chef
 
         def find_lld_rule_ids(connection, template_id, key)
           request = {
-            :method => 'discoveryrule.get',
+            :method => 'discoveryrules.get',
             :params => {
               :templated => true,
               :templateids => template_id,
@@ -147,7 +147,7 @@ class Chef
 
         def find_trigger_ids(connection, description)
           request = {
-            :method => 'trigger.get',
+            :method => 'triggers.get',
             :params => {
               :search => {
                 :description => description
@@ -159,7 +159,7 @@ class Chef
 
         def find_trigger_prototype_ids(connection, description)
           request = {
-            :method => 'triggerprototype.get',
+            :method => 'triggerprototypes.get',
             :params => {
               :search => {
                 :description => description
@@ -171,7 +171,7 @@ class Chef
 
         def find_item_ids(connection, template_id, key, name = nil)
           request = {
-            :method => 'item.get',
+            :method => 'items.get',
             :params => {
               :hostids => template_id,
               :search => {
@@ -190,7 +190,7 @@ class Chef
 
         def find_item_prototype_ids(connection, template_id, key, discovery_rule_id = nil)
           request = {
-            :method => 'itemprototype.get',
+            :method => 'itemprototypes.get',
             :params => {
               :templateids => template_id,
               :search => {
@@ -206,7 +206,7 @@ class Chef
 
         def find_item_ids_on_host(connection, host, key)
           request = {
-            :method => 'item.get',
+            :method => 'items.get',
             :params => {
               :host => host,
               :search => {
@@ -219,7 +219,7 @@ class Chef
 
         def find_graph_ids(connection, name)
           request = {
-            :method => 'graph.get',
+            :method => 'graphs.get',
             :params => {
               :filter => {
                 :name => name
@@ -231,7 +231,7 @@ class Chef
 
         def find_graph_prototype_ids(connection, name)
           request = {
-            :method => 'graphprototype.get',
+            :method => 'graphprototypes.get',
             :params => {
               :filter => {
                 :name => name

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bill.warner@gmail.com'
 license 'Apache 2.0'
 description 'Adds Zabbix Server related LWRPs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.3'
+version '0.1.4'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bill.warner@gmail.com'
 license 'Apache 2.0'
 description 'Adds Zabbix Server related LWRPs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bill.warner@gmail.com'
 license 'Apache 2.0'
 description 'Adds Zabbix Server related LWRPs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.2'
+version '0.1.3'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bill.warner@gmail.com'
 license 'Apache 2.0'
 description 'Adds Zabbix Server related LWRPs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.1.1'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'
@@ -12,3 +12,5 @@ supports 'centos', '>= 5.0'
 supports 'oracle', '>= 5.0'
 
 recommends 'zabbix-agent'
+
+depends 'zabbix'

--- a/providers/api_call.rb
+++ b/providers/api_call.rb
@@ -9,7 +9,7 @@ action :call do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end
 

--- a/providers/application.rb
+++ b/providers/application.rb
@@ -14,7 +14,7 @@ action :create do
         :method => 'application.create',
         :params => {
           :name => new_resource.name,
-          :templateid => template_ids.first['templateid']
+          :hostid => template_ids.first['templateid']
         }
       }
       connection.query(request)

--- a/providers/application.rb
+++ b/providers/application.rb
@@ -24,6 +24,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/application.rb
+++ b/providers/application.rb
@@ -1,6 +1,6 @@
 action :create do
   Chef::Zabbix.with_connection(new_resource.server_connection) do |connection|
-    # Convert the "hostname" (a template name) into a hostid
+    # Convert the "hostname" (a template name) into a templateid
 
     template_ids = Zabbix::API.find_template_ids(connection, new_resource.template)
     if template_ids.empty?
@@ -14,7 +14,7 @@ action :create do
         :method => 'application.create',
         :params => {
           :name => new_resource.name,
-          :hostid => template_ids.first['hostid']
+          :templateid => template_ids.first['templateid']
         }
       }
       connection.query(request)

--- a/providers/discovery_rule.rb
+++ b/providers/discovery_rule.rb
@@ -5,7 +5,7 @@ action :create do
       Chef::Application.fatal! "Could not find a template named #{new_resource.template}"
     end
 
-    template_id = template_ids.first['hostid']
+    template_id = template_ids.first['templateid']
 
     method = 'discoveryrule.create'
     params = {}

--- a/providers/discovery_rule.rb
+++ b/providers/discovery_rule.rb
@@ -44,6 +44,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/graph.rb
+++ b/providers/graph.rb
@@ -62,6 +62,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -287,7 +287,7 @@ action :update do
 end
 
 def load_current_resource
-  run_context.include_recipe 'libzabbix::_providers_common'
+  run_context.include_recipe 'liblibzabbix::_providers_common'
   require 'zabbixapi'
 end
 

--- a/providers/host_group.rb
+++ b/providers/host_group.rb
@@ -14,7 +14,7 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 
   @current_resource = Chef::Resource::ZabbixHostGroup.new(@new_resource.group)

--- a/providers/hostgroup.rb
+++ b/providers/hostgroup.rb
@@ -19,6 +19,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/interface.rb
+++ b/providers/interface.rb
@@ -51,6 +51,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/item.rb
+++ b/providers/item.rb
@@ -68,6 +68,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/item.rb
+++ b/providers/item.rb
@@ -5,7 +5,7 @@ action :create do
       Chef::Application.fatal! "Could not find a template named #{new_resource.template}"
     end
 
-    template_id = template_ids.first['hostid']
+    template_id = template_ids.first['templateid']
 
     application_ids = new_resource.applications.map do |application|
       app_ids = Zabbix::API.find_application_ids(connection, application, template_id)

--- a/providers/template.rb
+++ b/providers/template.rb
@@ -23,6 +23,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/trigger.rb
+++ b/providers/trigger.rb
@@ -40,6 +40,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/trigger_dependency.rb
+++ b/providers/trigger_dependency.rb
@@ -52,6 +52,6 @@ action :create do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -132,7 +132,7 @@ action :delete do
 end
 
 def load_current_resource
-  run_context.include_recipe 'zabbix::_providers_common'
+  run_context.include_recipe 'libzabbix::_providers_common'
   require 'zabbixapi'
 end
 


### PR DESCRIPTION
Zabbix 3.0 api changed the hostid keyname to templateid in the item class. Updated all code to allow for proper functionality of searching for templateids.

Also removed the dependency on the zabbix cookbook and replaced it with the libzabbix cookbook to allow for proper inclusion of _providers_common recipe, which installs the proper zabbixapi gem version.
