### PR TITLE
Fix circular dependency between libzabbix and zabbix-agent

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ supports 'redhat', '>= 5.0'
 supports 'centos', '>= 5.0'
 supports 'oracle', '>= 5.0'
 
-recommends 'zabbix-agent'
+suggests 'zabbix-agent'


### PR DESCRIPTION
faild `berks install`

``` bash
$ berks install
There is a circular dependency between zabbix-agent and libzabbix
```

same probrem https://github.com/TD-4242/zabbix-agent/issues/13
## Problem points

https://github.com/TD-4242/zabbix-agent/blob/master/metadata.rb#L21
https://github.com/TD-4242/cookbook-libzabbix/blob/master/metadata.rb#L14

is this a circular dependency.
## Fix

`recommends` is depends. to `circular dependency` 
I choice `suggests`. ref: https://docs.chef.io/config_rb_metadata.html

`suggests` is not depends, show info only.
